### PR TITLE
remove sh tag from wrestic help

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ Copy `wrestic.toml` to `/home/$USER/.config/wrestic/wrestic.toml` and modify the
 
 Simply run `sudo wrestic`.
 
-```sh
+```
 $ wrestic help
 
 Restic wrapper built in Rust


### PR DESCRIPTION
the formatting isn’t correct in the case of command *output*.