### PR TITLE
feat: add feature no-self-update

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,3 +27,6 @@ serde_json = "1.0.115"
 sudo = "0.6.0"
 tar = "0.4.40"
 which = "6.0.1"
+
+[features]
+no-self-update = []


### PR DESCRIPTION
To disable self-update for package manager installs.

To build without self-updates, run with `--features no-self-update`.
e.g. `cargo run --features no-self-update update`

Rustup works in the same way:
- https://github.com/rust-lang/rustup/blob/9955b9f889889a495b380e73709db5480c6a656b/Cargo.toml#L29
- https://github.com/rust-lang/rustup/blob/9955b9f889889a495b380e73709db5480c6a656b/src/cli/self_update.rs#L96
