### PR TITLE
feat: add `wrestic completions` (writes to stdout)

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -61,6 +61,8 @@ enum Commands {
     #[clap(short_flag = 'c', allow_hyphen_values = true)]
     #[command(arg_required_else_help = true)]
     Custom { args: Vec<String> },
+    /// Generate tab-completion scripts for your shell
+    Completions { shell: Shell },
 }
 
 fn handle_completions(cli: &Cli) -> Result<()> {
@@ -109,6 +111,14 @@ fn handle_commands(cli: &Cli) -> Result<()> {
         }
         Some(Commands::Custom { args }) => {
             custom(args)?;
+        }
+        Some(Commands::Completions { shell }) => {
+            clap_complete::generate(
+                *shell,
+                &mut Cli::command(),
+                "wrestic",
+                &mut std::io::stdout().lock(),
+            );
         }
         None => {
             selector()?;


### PR DESCRIPTION
This adds `wrestic completions`.

This is the standard (as observed by me, at least).
One example is [Starship](https://github.com/starship/starship/blob/f60326de42aa97bc3123ae8f574e41ad7c6ea7fe/src/main.rs#L239).
It would also make it a lot easier to include (all) completions in packages.

I left `wrestic --generate` in place, but haven’t looked at it further.